### PR TITLE
 Disable TypeScript support by default 

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,44 @@ import '@/icons/github.svg'
 {{ icon('github') | safe }}
 ```
 
+### Environment variables
+
+#### `NODE_ENV`
+
+> Type: `'development' | 'production' | none` <br/>
+> Default: `'development'`
+
+Indicates the current mode.
+
+#### `OUTPUT_DIR`
+
+> Type: `string` <br/>
+> Default: `'dist'`
+
+Indicates the directory where the production build files will be generated.
+
+#### `PUBLIC_PATH`
+
+> Type: `string` <br/>
+> Default: `'/'`
+
+Indicates the base URL your project bundle will be deployed at.
+
+#### `SOURCE_DIR`
+
+> Type: `string` <br/>
+> Default: `'src'`
+
+Indicates the directory where the source files are located.
+
+#### `TS_SUPPORT`
+
+> Type: `'true' | 'false' | none` <br/>
+> Default: `none`
+
+Indicates whether TypeScript support should be enabled. <br/>
+*`none` is equal to `false`*
+
 <br/>
 
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Webpack + Nunjucks boilerplate for static websites that has all the necessary mo
 
 ## ⚗️ Features
 - [Webpack](https://webpack.js.org)
-- [Nunjucks (supports multiple pages)](https://mozilla.github.io/nunjucks)
+- [Nunjucks](https://mozilla.github.io/nunjucks) (supports multiple pages)
 - [Babel](https://babeljs.io)
 - [TypeScript](https://typescriptlang.org) (disabled by default)
 - [ESLint](https://eslint.org)
@@ -60,7 +60,7 @@ yarn deploy
 
 
 
-## 📘 Helpers
+## 📘 Documentation
 
 ### TypeScript Support
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Webpack + Nunjucks boilerplate for static websites that has all the necessary mo
 - [Webpack](https://webpack.js.org)
 - [Nunjucks (supports multiple pages)](https://mozilla.github.io/nunjucks)
 - [Babel](https://babeljs.io)
-- [TypeScript](https://www.typescriptlang.org)
+- [TypeScript](https://typescriptlang.org) (disabled by default)
 - [ESLint](https://eslint.org)
 - [Sass](https://sass-lang.com)
 - [PostCSS](https://postcss.org)
@@ -61,6 +61,13 @@ yarn deploy
 
 
 ## 📘 Helpers
+
+### TypeScript Support
+
+By default, TypeScript support is disabled. To enable it, set the `TS_SUPPORT` environment variable to `true` in `package.json`.
+```bash
+... TS_SUPPORT=true ...
+```
 
 ### Multiple pages
 

--- a/config/constants/index.js
+++ b/config/constants/index.js
@@ -4,10 +4,16 @@ const CWD = process.cwd()
 
 module.exports = {
   /**
-   * Whether webpack is in development mode.
+   * Indicates whether to run the webpack in development mode or not.
    * @const {Boolean}
    */
   IS_DEV_MODE: process.env.NODE_ENV === 'development',
+
+  /**
+   * Indicates whether to enable TypeScript support or not.
+   * @const {Boolean}
+   */
+  IS_TS_SUPPORTED: process.env.TS_SUPPORT === 'true',
 
   /**
    * The absolute path to the directory where the
@@ -17,14 +23,14 @@ module.exports = {
   OUTPUT_DIR: path.resolve(CWD, process.env.OUTPUT_DIR || 'dist'),
 
   /**
-   * The base path for assets(javascript, images, fonts, etc).
+   * The base path for assets (javascript, images, fonts, etc).
    * @const {String}
    */
   PUBLIC_PATH: process.env.PUBLIC_PATH || '/',
 
   /**
-   * The absolute path to the source directory.
+   * The absolute path to the directory where the source files are located.
    * @const {String}
    */
-  SOURCE_DIR: path.resolve(CWD, 'src')
+  SOURCE_DIR: path.resolve(CWD, process.env.SOURCE_DIR || 'src')
 }

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -2,7 +2,12 @@ const { merge } = require('webpack-merge')
 const commonConfig = require('./webpack/webpack.common.config.js')
 const developmentConfig = require('./webpack/webpack.development.config.js')
 const productionConfig = require('./webpack/webpack.production.config.js')
-const { IS_DEV_MODE } = require('./constants')
+const typescriptConfig = require('./webpack/webpack.typescript.config.js')
+const { IS_TS_SUPPORTED, IS_DEV_MODE } = require('./constants')
 
 
-module.exports = merge(commonConfig, IS_DEV_MODE ? developmentConfig : productionConfig)
+module.exports = merge(
+  commonConfig,
+  IS_DEV_MODE ? developmentConfig : productionConfig,
+  IS_TS_SUPPORTED && typescriptConfig
+)

--- a/config/webpack/webpack.common.config.js
+++ b/config/webpack/webpack.common.config.js
@@ -3,9 +3,7 @@ const htmlPlugin = require('../plugins/html.plugin.js')
 const eslintPlugin = require('../plugins/eslint.plugin.js')
 const stylelintPlugin = require('../plugins/stylelint.plugin.js')
 const clearTerminal = require('../plugins/clearTerminal.plugin.js')
-const forkTSChecker = require('../plugins/forkTSChecker.plugin.js')
 const javascriptLoader = require('../loaders/javascript.loader.js')
-const typescriptLoader = require('../loaders/typescript.loader.js')
 const nunjucksLoader = require('../loaders/nunjucks.loader.js')
 const svgLoader = require('../loaders/svg.loader.js')
 
@@ -17,7 +15,7 @@ module.exports = {
     common: ['./js/app', './js/dev/icons', './sass/app']
   },
   resolve: {
-    extensions: ['.js', '.ts', '.tsx', '.sass', '.png', '.jpg', '.svg'],
+    extensions: ['.js', '.sass', '.png', '.jpg', '.svg'],
     alias: {
       '@': SOURCE_DIR
     }
@@ -26,14 +24,12 @@ module.exports = {
   plugins: [
     clearTerminal,
     ...htmlPlugin,
-    forkTSChecker,
     eslintPlugin,
     stylelintPlugin
   ],
   module: {
     rules: [
       javascriptLoader,
-      typescriptLoader,
       nunjucksLoader,
       svgLoader
     ]

--- a/config/webpack/webpack.typescript.config.js
+++ b/config/webpack/webpack.typescript.config.js
@@ -1,0 +1,17 @@
+const typescriptLoader = require('../loaders/typescript.loader.js')
+const forkTSChecker = require('../plugins/forkTSChecker.plugin.js')
+
+
+module.exports = {
+  resolve: {
+    extensions: ['.ts', '.tsx']
+  },
+  plugins: [
+    forkTSChecker
+  ],
+  module: {
+    rules: [
+      typescriptLoader
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "license": "MIT",
   "scripts": {
     "start": "yarn serve",
-    "serve": "cross-env NODE_ENV=development webpack serve --profile --progress --config ./config/webpack.config.js",
-    "build": "cross-env NODE_ENV=production webpack --profile --progress --config ./config/webpack.config.js",
+    "serve": "cross-env NODE_ENV=development TS_SUPPORT=false webpack serve --profile --progress --config ./config/webpack.config.js",
+    "build": "cross-env NODE_ENV=production TS_SUPPORT=false webpack --profile --progress --config ./config/webpack.config.js",
     "deploy": "git subtree push --prefix dist origin gh-pages"
   },
   "devDependencies": {


### PR DESCRIPTION
By default, TypeScript support is disabled. To enable it, set the `TS_SUPPORT` environment variable to `true` in `package.json`
```bash
... TS_SUPPORT=true ...
```