### PR TITLE
Update fork-ts-checker-webpack-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "css-loader": "^6.8.1",
     "eslint": "^8.55.0",
     "eslint-webpack-plugin": "^4.0.1",
-    "fork-ts-checker-webpack-plugin": "^6.5.2",
+    "fork-ts-checker-webpack-plugin": "^6.5.3",
     "html-loader": "^4.2.0",
     "html-webpack-plugin": "^5.5.4",
     "lint-staged": "^15.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3285,10 +3285,10 @@ for-in@^1.0.2:
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
   integrity sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==
 
-fork-ts-checker-webpack-plugin@^6.5.2:
-  version "6.5.2"
-  resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-6.5.2.tgz#4f67183f2f9eb8ba7df7177ce3cf3e75cdafb340"
-  integrity sha512-m5cUmF30xkZ7h4tWUgTAcEaKmUW7tfyUyTqNNOz7OxWJ0v1VWKTcOvH8FWHUwSjlW/356Ijc9vi3XfcPstpQKA==
+fork-ts-checker-webpack-plugin@^6.5.3:
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-6.5.3.tgz#eda2eff6e22476a2688d10661688c47f611b37f3"
+  integrity sha512-SbH/l9ikmMWycd5puHJKTkZJKddF4iRLyW3DeZ08HTI7NGyLS38MXd/KGgeWumQO7YNQbW2u/NtPT2YowbPaGQ==
   dependencies:
     "@babel/code-frame" "^7.8.3"
     "@types/json-schema" "^7.0.5"


### PR DESCRIPTION
Fixes the "TypeError: Cannot set property mark of #<Object> which has only a getter"